### PR TITLE
add #! line and mark executable each python file

### DIFF
--- a/InverterSink.py
+++ b/InverterSink.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from openmdao.api import Component, ScipyGMRES, NLGaussSeidel, IndepVarComp, ScipyOptimizer
 from openmdao.units.units import convert_units as cu
 from numpy import tanh, arange

--- a/PowerBusTransient.py
+++ b/PowerBusTransient.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from openmdao.api import Component, ScipyGMRES, Newton, IndepVarComp
 from openmdao.units.units import convert_units as cu
 from math import pi

--- a/WingTemp.py
+++ b/WingTemp.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from openmdao.api import Component, ScipyGMRES, Newton, IndepVarComp
 from openmdao.units.units import convert_units as cu
 

--- a/ext_motor_ht.py
+++ b/ext_motor_ht.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import numpy as np
 import math as m
 import matplotlib.pyplot as plt

--- a/fin_opt.py
+++ b/fin_opt.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import numpy as np
 import math as m
 

--- a/flight_conditions.py
+++ b/flight_conditions.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from openmdao.api import Component, Group, ScipyGMRES, Newton, IndepVarComp
 from openmdao.units.units import convert_units as cu
 from math import pi

--- a/heatSink2.py
+++ b/heatSink2.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from openmdao.api import Component, ScipyGMRES, NLGaussSeidel, IndepVarComp, ScipyOptimizer
 from openmdao.units.units import convert_units as cu
 from numpy import tanh, arange, meshgrid, empty, exp, zeros

--- a/heatSink25.py
+++ b/heatSink25.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 from numpy import tanh, arange, meshgrid, empty, exp, zeros
 from numpy import sqrt

--- a/heistSink.py
+++ b/heistSink.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
     HEIST Inverter Heat Sink
         Determines the steady state temperature of the HEIST nacelle.

--- a/rotor3.py
+++ b/rotor3.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 
     self.add_param('R3nacOD', 35., units='me-3',  desc='Nacelle OD')

--- a/splineSink.py
+++ b/splineSink.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import interpolate


### PR DESCRIPTION
This lets me run these cases from the file name, e.g. `./WingTemp.py` instead of `python3 WingTemp.py`. I'm not sure it's appropriate for all these files, though.
